### PR TITLE
Adding __pow__ magic method for ParticleOperator

### DIFF
--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -655,6 +655,10 @@ class ParticleOperator:
                     updated_states.append(state_prime)
             return FockSum(updated_states)
 
+    def __pow__(self, other):
+        assert isinstance(other, (int, np.int64))
+        return ParticleOperator(((self.input_string + " ") * other)[:-1])
+
 
 class ParticleOperatorSum:
     # Sum of ParticleOperator instances

--- a/tests/test_particleoperator.py
+++ b/tests/test_particleoperator.py
@@ -73,3 +73,9 @@ def test_add_overlapping_particleoperatorsums():
     assert pos1 + pos2 == 2 * ParticleOperator("b1") + ParticleOperator(
         "d1"
     ) + ParticleOperator("a2")
+
+
+@pytest.mark.parametrize("power", np.arange(1, 10, 1))
+def test_particle_operator_to_some_power(power):
+    operator = ParticleOperator("a0")
+    assert operator**power == ParticleOperator((("a0" + " ") * power)[:-1])


### PR DESCRIPTION
After this PR, `__pow__()` method will be implemented into the `ParticleOperator` class