### PR TITLE
Hash openparticle

### DIFF
--- a/openparticle/__init__.py
+++ b/openparticle/__init__.py
@@ -5,4 +5,5 @@ from openparticle.src import (
     FermionOperator,
     AntifermionOperator,
     BosonOperator,
+    NumberOperator,
 )

--- a/openparticle/__init__.py
+++ b/openparticle/__init__.py
@@ -1,10 +1,7 @@
 from openparticle.src import (
     Fock,
     ConjugateFock,
-    FockSum,
-    ConjugateFockSum,
     ParticleOperator,
-    ParticleOperatorSum,
     FermionOperator,
     AntifermionOperator,
     BosonOperator,

--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -659,6 +659,22 @@ class ParticleOperator:
         assert isinstance(other, (int, np.int64))
         return ParticleOperator(((self.input_string + " ") * other)[:-1])
 
+    def __sub__(self, other):
+        if isinstance(other, ParticleOperator):
+            if self.input_string == other.input_string:
+                updated_coeff = self.coeff - other.coeff
+                if updated_coeff == 0:
+                    return 0
+                else:
+                    return ParticleOperator(self.input_string, updated_coeff)
+            else:
+                return ParticleOperatorSum([self, (-1) * other])
+        if isinstance(other, ParticleOperatorSum):
+            output = [self] + [
+                (-1) * ParticleOperator(j.input_string) for j in other.operator_list
+            ]
+            return ParticleOperatorSum(output).cleanup()
+
 
 class ParticleOperatorSum:
     # Sum of ParticleOperator instances
@@ -728,6 +744,16 @@ class ParticleOperatorSum:
             return ParticleOperatorSum(output).cleanup()
         elif isinstance(other, ParticleOperatorSum):
             output = self.operator_list + other.operator_list
+            return ParticleOperatorSum(output).cleanup()
+
+    def __sub__(self, other):
+        if isinstance(other, ParticleOperator):
+            output = self.operator_list + [(-1) * ParticleOperator(other.input_string)]
+            return ParticleOperatorSum(output).cleanup()
+        elif isinstance(other, ParticleOperatorSum):
+            output = self.operator_list + [
+                (-1) * ParticleOperator(j.input_string) for j in other.operator_list
+            ]
             return ParticleOperatorSum(output).cleanup()
 
     def __mul__(self, other):

--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -748,7 +748,9 @@ class ParticleOperatorSum:
 
     def __sub__(self, other):
         if isinstance(other, ParticleOperator):
-            output = self.operator_list + [(-1) * ParticleOperator(other.input_string)]
+            output = self.operator_list + [
+                (-other.coeff) * ParticleOperator(other.input_string)
+            ]
             return ParticleOperatorSum(output).cleanup()
         elif isinstance(other, ParticleOperatorSum):
             output = self.operator_list + [

--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -179,7 +179,7 @@ class ParticleOperator:
             raise ValueError("input must be dictionary or op string")
 
         if perform_cleanup:
-            self.cleanup()
+            self._cleanup()
 
     def __add__(self, other: "ParticleOperator") -> "ParticleOperator":
 
@@ -203,7 +203,7 @@ class ParticleOperator:
             output_str += "\n"
         return output_str
 
-    def cleanup(self, zero_threshold=1e-15) -> None:
+    def _cleanup(self, zero_threshold=1e-15) -> None:
         """
         remove terms below threshold
         """
@@ -266,7 +266,7 @@ class ParticleOperator:
 
         return ParticleOperator(dagger_dict)
 
-    def cleanup(self, zero_threshold=1e-15) -> None:
+    def _cleanup(self, zero_threshold=1e-15) -> None:
         """
         remove terms below threshold
         """

--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -217,11 +217,40 @@ class ParticleOperator:
     def display(self):
         display(self.latex_string())
 
-    def split(self):
-        pass
+    def split(self) -> List:
+        split_list = []
+        if len(self.op_dict) == 1:
+            for oper in list(self.op_dict.keys())[0].split(" "):
+                if oper[0] == "a":  # boson
+                    split_list.append(BosonOperator(oper[1:]))
+                elif oper[0] == "b":  # fermion
+                    split_list.append(FermionOperator(oper[1:]))
+                elif oper[0] == "d":  # antifermion
+                    split_list.append(AntifermionOperator(oper[1:]))
+            return split_list
+        else:
+            return NotImplemented
 
-    def dagger(self):
-        pass
+    def to_list(self) -> List:
+        particle_op_list = []
+        for oper, coeff in self.op_dict.items():
+            particle_op_list.append(ParticleOperator({oper: coeff}))
+        return particle_op_list
+
+    def dagger(self) -> "ParticleOperator":
+        dagger_dict = {}
+
+        for i, coeff_i in self.op_dict.items():
+            dagger_str = ""
+            for oper in i.split(" ")[::-1]:
+                if oper[-1] == "^":
+                    dagger_str += oper[:-1]
+                else:
+                    dagger_str += oper + "^"
+                dagger_str += " "
+            dagger_dict[dagger_str[:-1]] = coeff_i
+
+        return ParticleOperator(dagger_dict)
 
     def cleanup(self, zero_threshold=1e-15) -> None:
         """
@@ -240,10 +269,23 @@ class ParticleOperator:
         return ParticleOperator(dict(zip(self.op_dict.keys(), other * coeffs)))
 
     def __mul__(self, other):
-        pass
+        if isinstance(other, ParticleOperator):
+            product_dict = {}
+            for op1, coeffs1 in list(self.op_dict.items()):
+                for op2, coeffs2 in list(other.op_dict.items()):
+                    product_dict[op1 + " " + op2] = coeffs1 * coeffs2
+            return ParticleOperator(product_dict)
+        if isinstance(other, Fock):
+            # TODO: Implement
+            pass
 
-    def __pow__(self, other):
-        pass
+    def __pow__(self, other) -> "ParticleOperator":
+        if len(self.op_dict) == 1:
+            return ParticleOperator(
+                ((str(list(self.op_dict.keys())[0]) + " ") * other)[:-1]
+            )
+        else:
+            return NotImplemented
 
     def __sub__(self, other):
         coeffs = list(other.op_dict.values())

--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -397,9 +397,6 @@ class ConjugateFockSum:
 class ParticleOperator:
 
     def __init__(self, op_dict: Union[Dict[str, complex], str] = dict()):
-        # Initializes particle operator in the form of b_n d_n a_n
-        # Parameters:
-        # input_string: e.g. 'b2^ a0'
 
         if isinstance(op_dict, str):
             self.op_dict = {op_dict: 1}
@@ -433,19 +430,27 @@ class ParticleOperator:
     def __repr__(self) -> str:
         return self.__str__()
 
+    def latex_string(self) -> Latex:
+        pattern = r"(\d+)"
+        replacement = r"_{\1}"
+        latex_str = ""
+        for s, coeff in self.op_dict.items():
+            new_s = s.replace("^", "^{\dagger}")
+            latex_str += f"{coeff} {re.sub(pattern, replacement, new_s)} +"
+
+        return Latex("$" + latex_str[:-1] + "$")
+
+    def display(self):
+        display(self.latex_string())
+
     def split(self):
         pass
 
     def dagger(self):
         pass
 
-    def display(self):
-        display(Latex("$" + self.op_string + "$"))
-
     def __rmul__(self, other):
-        if isinstance(other, (int, float)):
-            self.coeff *= other
-            return ParticleOperator(self.input_string, self.coeff)
+        pass
 
     def impose_parity_jw(self, state, mode):
 
@@ -549,46 +554,13 @@ class ParticleOperator:
                 )
 
     def __mul__(self, other):
-        if isinstance(other, ParticleOperator):
-            updated_coeff = self.coeff * other.coeff
-            return ParticleOperator(
-                self.input_string + " " + other.input_string, updated_coeff
-            )
-
-        elif isinstance(other, Fock):
-            po_coeff = self.coeff
-            for op in self.input_string.split(" ")[::-1]:
-                other = ParticleOperator(op).operate_on_state(other)
-
-            return po_coeff * other
-
-        elif isinstance(other, FockSum):
-            updated_states = []
-            for state in other.states_list:
-                state_prime = self.operate_on_state(state)
-                if isinstance(state_prime, Fock):
-                    updated_states.append(state_prime)
-            return FockSum(updated_states)
+        pass
 
     def __pow__(self, other):
-        assert isinstance(other, (int, np.int64))
-        return ParticleOperator(((self.input_string + " ") * other)[:-1])
+        pass
 
     def __sub__(self, other):
-        if isinstance(other, ParticleOperator):
-            if self.input_string == other.input_string:
-                updated_coeff = self.coeff - other.coeff
-                if updated_coeff == 0:
-                    return 0
-                else:
-                    return ParticleOperator(self.input_string, updated_coeff)
-            else:
-                return ParticleOperatorSum([self, (-1) * other])
-        if isinstance(other, ParticleOperatorSum):
-            output = [self] + [
-                (-1) * ParticleOperator(j.input_string) for j in other.operator_list
-            ]
-            return ParticleOperatorSum(output).cleanup()
+        pass
 
 
 class ParticleOperatorSum:

--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -86,7 +86,7 @@ class Fock:
                         split_coeff *= new_coeff  # Update coeff for every op in product
                     output_state_dict[next(iter(state.state_dict))] = (
                         split_coeff * op_coeff * state_coeff
-                    )
+                    ) + output_state_dict.get(next(iter(state.state_dict)), 0)
             return Fock(state_dict=output_state_dict)._cleanup()
 
     def __add__(self, other: "Fock") -> "Fock":

--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -522,3 +522,16 @@ class BosonOperator(ParticleOperator):
             ),
             coeff,
         )
+
+
+class NumberOperator(ParticleOperator):
+    def __init__(self, particle_type, mode):
+        self.particle_type = particle_type
+        self.mode = mode
+        super().__init__(
+            self.particle_type
+            + str(self.mode)
+            + "^ "
+            + self.particle_type
+            + str(self.mode),
+        )

--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -100,7 +100,7 @@ class Fock:
             new_dict = deepcopy(self.state_dict)
             for state, coeff in other.state_dict.items():
                 new_dict[state] = coeff + new_dict.get(state, 0)
-        out_state = Fock(state_dict=new_dict, perform_cleanup=True)
+        out_state = Fock(state_dict=new_dict)._cleanup()
         if len(out_state.state_dict) == 0:
             return 0
         else:
@@ -402,16 +402,19 @@ class FermionOperator(ParticleOperator):
 
     def _operate_on_state(self, other) -> "Fock":
         f_occ = list(list(other.state_dict.keys())[0][0])
+
         if self.creation and self.mode not in f_occ:
             f_occ.append(self.mode)
+            # Get parity
+            coeff = (-1) ** len(f_occ[: f_occ.index(self.mode)])
         elif not self.creation and self.mode in f_occ:
+            # Get parity
+            coeff = (-1) ** len(f_occ[: f_occ.index(self.mode)])
             f_occ.remove(self.mode)
         else:
             return Fock([], [], []), 0
 
         f_occ = sorted(f_occ)
-        # Get parity
-        coeff = (-1) ** len(f_occ[: f_occ.index(self.mode)])
 
         return (
             Fock(

--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -111,6 +111,13 @@ class Fock:
     def dagger(self):
         return ConjugateFock(state_dict=self.state_dict)
 
+    def __sub__(self, other: "Fock") -> "Fock":
+        coeffs = list(other.state_dict.values())
+        neg_other = Fock(
+            state_dict=dict(zip(other.state_dict.keys(), -1 * np.array(coeffs)))
+        )
+        return self + neg_other
+
 
 class ConjugateFock:
     """
@@ -333,9 +340,7 @@ class ParticleOperator:
                 for op2, coeffs2 in list(other.op_dict.items()):
                     product_dict[op1 + " " + op2] = coeffs1 * coeffs2
             return ParticleOperator(product_dict)
-        if isinstance(other, Fock):
-            # TODO: Implement
-            pass
+        return NotImplemented
 
     def __pow__(self, other) -> "ParticleOperator":
         if len(self.op_dict) == 1:

--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -370,6 +370,13 @@ class ParticleOperator:
         )
         return self + neg_other
 
+    def normal_order(self) -> "ParticleOperator":
+        # Returns a new ParticleOperator object with a normal ordered hash table
+        # normal ordering: b^dagger before b; d^dagger before d; a^dagger before a
+        # b2 b1^ a0 b3 -> b1^ b2 b3 a0
+        # return ParticleOperator(normal_ordered_dict)
+        pass
+
 
 class FermionOperator(ParticleOperator):
 

--- a/openparticle/utils.py
+++ b/openparticle/utils.py
@@ -20,3 +20,22 @@ def generate_matrix_from_basis(operator: op.ParticleOperator, basis: List[op.Foc
             matrix[i][j] = matrix_element
 
     return matrix
+
+
+def latexify(string):
+    # Split terms on whitespace
+    terms = string.split()
+
+    processed_terms = []
+    for term in terms:
+        # Insert underscores between letters and numbers
+        term = re.sub(r"([a-zA-Z])(\d)", r"\1_\2", term)
+        term = re.sub(r"(\d)([a-zA-Z])", r"\1_\2", term)
+
+        # Add † symbol after any term with ^
+        if "^" in term:
+            term += "†"
+
+        processed_terms.append(term)
+
+    return " ".join(processed_terms)

--- a/tests/test_class_integration.py
+++ b/tests/test_class_integration.py
@@ -27,7 +27,7 @@ def test_defined_particleoperator_acts_on_fock_state():
     operator = ParticleOperator("b0^")
     state = Fock([], [1], [])
 
-    assert operator * state == Fock([0], [1], [])
+    assert (operator * state).state_dict == (Fock([0], [1], [])).state_dict
 
 
 def test_defined_particleoperatorsum_act_on_matrix_element_1():
@@ -50,14 +50,17 @@ def test_defined_particleoperator_acts_on_fock_sum_diff():
     operator = ParticleOperator("b0^")
     state = Fock([], [1], []) + Fock([], [2], [])
 
-    assert (operator * state).__str__() == "1.0 * |0; 1; ⟩ + 1.0 * |0; 2; ⟩"
+    assert (operator * state).state_dict == {
+        ((0,), (1,), ()): 1,
+        ((0,), (2,), ()): 1,
+    }
 
 
 def test_defined_particleoperator_acts_on_fock_sum_same():
     operator = ParticleOperator("b0^")
     state = Fock([], [1], []) + Fock([], [1], [])
 
-    assert (operator * state).__str__() == "2.0 * |0; 1; ⟩"
+    assert (operator * state).state_dict == {((0,), (1,), ()): 2.0}
 
 
 def test_defined_matrix_elem_fock_sum_1():
@@ -268,20 +271,3 @@ def test_bra_sum_times_bra_sum_diff():
     bra_sum = ConjugateFock([0], [1], []) + ConjugateFock([0], [2], [])
 
     assert bra_sum * bra_sum is None
-
-
-def test_ket_times_ket():
-    ket = Fock([], [1], [])
-
-    assert ket * ket is None
-
-
-# unsupported FockSum * FockSum
-# def test_ket_sum_times_ket_sum():
-#     ket_sum = Fock([], [1], []) + Fock([], [3], [])
-
-#     assert ket_sum * ket_sum is None
-
-
-def test_random_particleoperator_acts_on_fock_state():
-    pass

--- a/tests/test_class_integration.py
+++ b/tests/test_class_integration.py
@@ -1,10 +1,7 @@
 from openparticle import (
     ParticleOperator,
-    ParticleOperatorSum,
     Fock,
-    FockSum,
     ConjugateFock,
-    ConjugateFockSum,
 )
 import numpy as np
 import pytest
@@ -17,12 +14,14 @@ def test_defined_matrix_element_1():
 
     assert bra * operator * ket == 1.0
 
+
 def test_defined_matrix_element_2():
     bra = ConjugateFock([1], [], [])
     operator = ParticleOperator("b0^")
     ket = Fock([], [], [])
 
     assert bra * operator * ket == 0
+
 
 def test_defined_particleoperator_acts_on_fock_state():
     operator = ParticleOperator("b0^")
@@ -38,12 +37,14 @@ def test_defined_particleoperatorsum_act_on_matrix_element_1():
 
     assert bra * operator * ket == 2.0
 
+
 def test_defined_particleoperatorsum_act_on_matrix_element_2():
     bra = ConjugateFock([1], [], [(1, 1)])
     operator = ParticleOperator("b1^") + ParticleOperator("a1^")
     ket = Fock([], [], [])
 
     assert bra * operator * ket == 0
+
 
 def test_defined_particleoperator_acts_on_fock_sum_diff():
     operator = ParticleOperator("b0^")
@@ -58,12 +59,14 @@ def test_defined_particleoperator_acts_on_fock_sum_same():
 
     assert (operator * state).__str__() == "2.0 * |0; 1; ⟩"
 
+
 def test_defined_matrix_elem_fock_sum_1():
     bra = ConjugateFock([0], [1], []) + ConjugateFock([0], [2], [])
     operator = ParticleOperator("b0^")
     state = Fock([], [1], []) + Fock([], [2], [])
 
     assert bra * operator * state == 2.0
+
 
 def test_defined_matrix_elem_fock_sum_2():
     bra = ConjugateFock([0], [1], [])
@@ -72,12 +75,14 @@ def test_defined_matrix_elem_fock_sum_2():
 
     assert bra * operator * state == 2.0
 
+
 def test_defined_matrix_elem_fock_sum_diff_1():
     bra = ConjugateFock([0], [], [])
     operator = ParticleOperator("b0^")
     state = Fock([], [1], []) + Fock([], [1], [])
 
     assert bra * operator * state == 0
+
 
 def test_defined_matrix_elem_fock_sum_diff_2():
     bra = ConjugateFock([0], [1], [])
@@ -86,12 +91,14 @@ def test_defined_matrix_elem_fock_sum_diff_2():
 
     assert bra * operator * state == 1.0
 
+
 def test_defined_conj_fock_sum_same():
     bra = ConjugateFock([0], [1], []) + ConjugateFock([0], [1], [])
     operator = ParticleOperator("b0^")
     state = Fock([], [1], [])
 
     assert bra * operator * state == 2.0
+
 
 def test_defined_conj_fock_sum_diff_1():
     bra = ConjugateFock([0], [1], []) + ConjugateFock([0], [2], [])
@@ -100,12 +107,14 @@ def test_defined_conj_fock_sum_diff_1():
 
     assert bra * operator * state == 1.0
 
+
 def test_defined_conj_fock_sum_diff_2():
     bra = ConjugateFock([0], [1], []) + ConjugateFock([0], [1], [])
     operator = ParticleOperator("b0^")
     state = Fock([], [], [])
 
     assert bra * operator * state == 0
+
 
 def test_defined_matrix_elem_in_sum_class_1():
     bra = ConjugateFock([0], [1], []) + ConjugateFock([0], [3], [])
@@ -114,12 +123,14 @@ def test_defined_matrix_elem_in_sum_class_1():
 
     assert bra * operator * state == 2.0
 
+
 def test_defined_matrix_elem_in_sum_class_2():
     bra = ConjugateFock([1], [1], []) + ConjugateFock([0], [3], [])
     operator = ParticleOperator("b0^")
     state = Fock([], [1], []) + Fock([], [3], [])
 
     assert bra * operator * state == 1.0
+
 
 def test_defined_matrix_elem_in_sum_class_3():
     bra = ConjugateFock([1], [1], []) + ConjugateFock([1], [3], [])
@@ -128,80 +139,149 @@ def test_defined_matrix_elem_in_sum_class_3():
 
     assert bra * operator * state == 0
 
+
 def test_defined_matrix_elem_in_fock_sum_class_multi_1():
-    bra = ConjugateFock([0], [1], []) + ConjugateFock([0], [2], []) + ConjugateFock([0], [3], []) + ConjugateFock([0], [4], []) + ConjugateFock([0], [5], [])
+    bra = (
+        ConjugateFock([0], [1], [])
+        + ConjugateFock([0], [2], [])
+        + ConjugateFock([0], [3], [])
+        + ConjugateFock([0], [4], [])
+        + ConjugateFock([0], [5], [])
+    )
     operator = ParticleOperator("b0^")
-    state = Fock([], [1], []) + Fock([], [2], []) + Fock([], [3], []) + Fock([], [4], []) + Fock([], [5], []) 
+    state = (
+        Fock([], [1], [])
+        + Fock([], [2], [])
+        + Fock([], [3], [])
+        + Fock([], [4], [])
+        + Fock([], [5], [])
+    )
 
     assert bra * operator * state == 5.0
 
+
 def test_defined_matrix_elem_in_fock_sum_class_multi_2():
-    bra = ConjugateFock([0], [1], []) + ConjugateFock([0], [3], []) + ConjugateFock([0], [3], []) + ConjugateFock([0], [3], []) + ConjugateFock([0], [3], [])
+    bra = (
+        ConjugateFock([0], [1], [])
+        + ConjugateFock([0], [3], [])
+        + ConjugateFock([0], [3], [])
+        + ConjugateFock([0], [3], [])
+        + ConjugateFock([0], [3], [])
+    )
     operator = ParticleOperator("b0^")
     state = Fock([], [1], []) + Fock([], [3], [])
 
     assert bra * operator * state == 5.0
 
+
 def test_defined_matrix_elem_in_particleoperator_sum_and_fock_sum_class_1():
-    bra = ConjugateFock([0], [1], []) + ConjugateFock([1], [3], []) 
+    bra = ConjugateFock([0], [1], []) + ConjugateFock([1], [3], [])
     operator = ParticleOperator("b0^") + ParticleOperator("b1^")
     state = Fock([], [1], []) + Fock([], [3], [])
 
     assert bra * operator * state == 2.0
 
+
 def test_defined_matrix_elem_in_particleoperator_sum_and_fock_sum_class_2():
-    bra = ConjugateFock([0], [1], []) + ConjugateFock([1], [3], []) + ConjugateFock([1], [3], []) 
-    operator = ParticleOperator("b0^") + ParticleOperator("b1^") + ParticleOperator("b1^")
+    bra = (
+        ConjugateFock([0], [1], [])
+        + ConjugateFock([1], [3], [])
+        + ConjugateFock([1], [3], [])
+    )
+    operator = (
+        ParticleOperator("b0^") + ParticleOperator("b1^") + ParticleOperator("b1^")
+    )
     state = Fock([], [1], []) + Fock([], [3], []) + Fock([], [3], [])
 
     assert bra * operator * state == 9.0
 
+
 def test_defined_matrix_elem_in_particleoperator_sum_and_fock_sum_class_multi_1():
-    bra = ConjugateFock([0], [1], []) + ConjugateFock([1], [2], []) + ConjugateFock([2], [3], []) + ConjugateFock([3], [4], []) + ConjugateFock([4], [5], [])
-    operator = ParticleOperator("b0^") + ParticleOperator("b1^") + ParticleOperator("b2^") + ParticleOperator("b3^") + ParticleOperator("b4^") 
-    state = Fock([], [1], []) + Fock([], [2], []) + Fock([], [3], []) + Fock([], [4], []) + Fock([], [5], []) 
+    bra = (
+        ConjugateFock([0], [1], [])
+        + ConjugateFock([1], [2], [])
+        + ConjugateFock([2], [3], [])
+        + ConjugateFock([3], [4], [])
+        + ConjugateFock([4], [5], [])
+    )
+    operator = (
+        ParticleOperator("b0^")
+        + ParticleOperator("b1^")
+        + ParticleOperator("b2^")
+        + ParticleOperator("b3^")
+        + ParticleOperator("b4^")
+    )
+    state = (
+        Fock([], [1], [])
+        + Fock([], [2], [])
+        + Fock([], [3], [])
+        + Fock([], [4], [])
+        + Fock([], [5], [])
+    )
 
     assert bra * operator * state == 5.0
 
+
 def test_defined_matrix_elem_in_particleoperator_sum_and_fock_sum_class_multi_2():
-    bra = ConjugateFock([0], [1], []) + ConjugateFock([0], [3], []) + ConjugateFock([0], [3], []) + ConjugateFock([0], [3], []) + ConjugateFock([0], [3], [])
-    operator = ParticleOperator("b0^") + ParticleOperator("b0^") 
+    bra = (
+        ConjugateFock([0], [1], [])
+        + ConjugateFock([0], [3], [])
+        + ConjugateFock([0], [3], [])
+        + ConjugateFock([0], [3], [])
+        + ConjugateFock([0], [3], [])
+    )
+    operator = ParticleOperator("b0^") + ParticleOperator("b0^")
     state = Fock([], [1], []) + Fock([], [3], [])
 
     assert bra * operator * state == 10.0
 
+
 def test_defined_matrix_elem_in_particleoperator_sum_and_fock_sum_class_multi_3():
-    bra = ConjugateFock([0], [1], []) + ConjugateFock([0], [3], []) + ConjugateFock([0], [3], []) + ConjugateFock([0], [3], []) + ConjugateFock([1], [3], [])
-    operator = ParticleOperator("b0^") + ParticleOperator("b0^") + ParticleOperator("b1^") 
+    bra = (
+        ConjugateFock([0], [1], [])
+        + ConjugateFock([0], [3], [])
+        + ConjugateFock([0], [3], [])
+        + ConjugateFock([0], [3], [])
+        + ConjugateFock([1], [3], [])
+    )
+    operator = (
+        ParticleOperator("b0^") + ParticleOperator("b0^") + ParticleOperator("b1^")
+    )
     state = Fock([], [1], []) + Fock([], [3], [])
 
     assert bra * operator * state == 9.0
+
 
 def test_bra_times_bra():
     bra = ConjugateFock([0], [1], [])
 
     assert bra * bra is None
 
+
 def test_bra_sum_times_bra_sum_same():
     bra_sum = ConjugateFock([0], [1], []) + ConjugateFock([0], [1], [])
 
     assert bra_sum * bra_sum is None
+
 
 def test_bra_sum_times_bra_sum_diff():
     bra_sum = ConjugateFock([0], [1], []) + ConjugateFock([0], [2], [])
 
     assert bra_sum * bra_sum is None
 
+
 def test_ket_times_ket():
     ket = Fock([], [1], [])
 
     assert ket * ket is None
+
 
 # unsupported FockSum * FockSum
 # def test_ket_sum_times_ket_sum():
 #     ket_sum = Fock([], [1], []) + Fock([], [3], [])
 
 #     assert ket_sum * ket_sum is None
+
 
 def test_random_particleoperator_acts_on_fock_state():
     pass

--- a/tests/test_fockstate.py
+++ b/tests/test_fockstate.py
@@ -31,34 +31,38 @@ def test_fock_states_add_two_different_states():
     state_1 = Fock([1], [2], [(0, 4)])
     state_2 = Fock([0], [], [(1, 1)])
     state_sum = state_1 + state_2
-    assert (
-        state_sum.__str__()
-        == "1.0 * |((1,), (2,), ((0, 4),))⟩ +\n1.0 * |((0,), (), ((1, 1),))⟩"
-    )
+    assert state_sum.state_dict == {
+        ((1,), (2,), ((0, 4),)): 1.0,
+        ((0,), (), ((1, 1),)): 1.0,
+    }
 
 
 def test_fock_states_add_two_same_states():
     state = Fock([1], [2], [(0, 4)])
     # assert state + state == 2 * state
-    assert (state + state).__str__() == "2.0 * |((1,), (2,), ((0, 4),))⟩"
+    assert (state + state).state_dict == {((1,), (2,), ((0, 4),)): 2}
 
 
 def test_add_fock_to_focksum():
     fsum = Fock([1], [2], []) + Fock([0], [], [])
     state = Fock([1], [], [])
 
-    assert (
-        fsum + state
-    ).__str__() == "1.0 * |((1,), (2,), ())⟩ +\n1.0 * |((0,), (), ())⟩ +\n1.0 * |((1,), (), ())⟩"
+    assert (fsum + state).state_dict == {
+        ((1,), (2,), ()): 1,
+        ((0,), (), ()): 1,
+        ((1,), (), ()): 1,
+    }
 
 
 def test_add_focksum_to_fock_with_proper_ordering():
     fsum = Fock([1], [2], []) + Fock([0], [], [])
     state = Fock([1], [], [])
 
-    assert (
-        state + fsum
-    ).__str__() == "1.0 * |((1,), (2,), ())⟩ +\n1.0 * |((0,), (), ())⟩ +\n1.0 * |((1,), (), ())⟩"
+    assert (state + fsum).state_dict == {
+        ((1,), (2,), ()): 1,
+        ((0,), (), ()): 1,
+        ((1,), (), ()): 1,
+    }
 
 
 # def test_focksum_normlization():
@@ -92,25 +96,28 @@ def test_fock_state_mul_by_constant(coeff):
 def test_conjugate_fock_states_add_two_different_states():
     state_1 = ConjugateFock([1], [2], [(0, 4)])
     state_2 = ConjugateFock([0], [], [(1, 1)])
-
-    assert (
-        state_1 + state_2
-    ).__str__() == "1.0 * ⟨((1,), (2,), ((0, 4),))| +\n1.0 * ⟨((0,), (), ((1, 1),))|"
+    state_sum = state_1 + state_2
+    assert state_sum.state_dict == {
+        ((1,), (2,), ((0, 4),)): 1.0,
+        ((0,), (), ((1, 1),)): 1.0,
+    }
 
 
 def test_conjugate_fock_states_add_two_same_states():
     state = ConjugateFock([1], [2], [(0, 4)])
     # assert state + state == 2 * state
-    assert (state + state).__str__() == "2.0 * ⟨((1,), (2,), ((0, 4),))|"
+    assert (state + state).state_dict == {((1,), (2,), ((0, 4),)): 2}
 
 
-def test_add_conjugatefock_to_conjugatefocksum():
+def test_add_conjugatefock_to_focksum():
     fsum = ConjugateFock([1], [2], []) + ConjugateFock([0], [], [])
     state = ConjugateFock([1], [], [])
 
-    assert (
-        fsum + state
-    ).__str__() == "1.0 * ⟨((1,), (2,), ())| +\n1.0 * ⟨((0,), (), ())| +\n1.0 * ⟨((1,), (), ())|"
+    assert (fsum + state).state_dict == {
+        ((1,), (2,), ()): 1,
+        ((0,), (), ()): 1,
+        ((1,), (), ()): 1,
+    }
 
 
 # def test_conjugatefocksum_normlization():

--- a/tests/test_fockstate.py
+++ b/tests/test_fockstate.py
@@ -1,4 +1,4 @@
-from openparticle import Fock, FockSum, ConjugateFock, ConjugateFockSum
+from openparticle import Fock, ConjugateFock
 import pytest
 import numpy as np
 
@@ -50,12 +50,14 @@ def test_add_fock_to_focksum():
     # assert fsum + state == FockSum([fsum.states_list[0], fsum.states_list[1], state])
     assert (fsum + state).__str__() == "1.0 * |1; 2; ⟩ + 1.0 * |0; ; ⟩ + 1.0 * |1; ; ⟩"
 
+
 def test_add_focksum_to_fock_with_proper_ordering():
     fsum = Fock([1], [2], []) + Fock([0], [], [])
     state = Fock([1], [], [])
 
     # assert state + fsum == FockSum([state, fsum.states_list[0], fsum.states_list[1]])
     assert (state + fsum).__str__() == "1.0 * |1; ; ⟩ + 1.0 * |1; 2; ⟩ + 1.0 * |0; ; ⟩"
+
 
 # ?????????
 def test_add_focksum_to_fock_with_wrong_ordering():
@@ -79,7 +81,9 @@ def test_add_focksum_to_different_focksum():
     #     ]
     # )
 
-    assert (fsum1 + fsum2).__str__() == "1.0 * |1; 2; ⟩ + 1.0 * |0; ; ⟩ + 1.0 * |3; 2; ⟩ + 1.0 * |1; ; ⟩"
+    assert (
+        fsum1 + fsum2
+    ).__str__() == "1.0 * |1; 2; ⟩ + 1.0 * |0; ; ⟩ + 1.0 * |3; 2; ⟩ + 1.0 * |1; ; ⟩"
 
 
 def test_add_focksum_to_overlapping_focksum():
@@ -89,7 +93,9 @@ def test_add_focksum_to_overlapping_focksum():
     # assert fsum1 + fsum2 == Fock([1], [2], []) + 2 * Fock([0], [], []) + Fock(
     #     [3], [2], []
     # )
-    assert (fsum1 + fsum2).__str__() == "1.0 * |1; 2; ⟩ + 2.0 * |0; ; ⟩ + 1.0 * |3; 2; ⟩"
+    assert (
+        fsum1 + fsum2
+    ).__str__() == "1.0 * |1; 2; ⟩ + 2.0 * |0; ; ⟩ + 1.0 * |3; 2; ⟩"
 
 
 def test_focksum_normlization():
@@ -179,7 +185,9 @@ def test_add_conjugatefocksum_to_different_conjugatefocksum():
     #     ]
     # )
 
-    assert (fsum1 + fsum2).__str__() == "1.0 * ⟨1; 2; | + 1.0 * ⟨0; ; | + 1.0 * ⟨3; 2; | + 1.0 * ⟨1; ; |"
+    assert (
+        fsum1 + fsum2
+    ).__str__() == "1.0 * ⟨1; 2; | + 1.0 * ⟨0; ; | + 1.0 * ⟨3; 2; | + 1.0 * ⟨1; ; |"
 
 
 def test_add_conjugatefocksum_to_overlapping_conjugatefocksum():
@@ -190,7 +198,9 @@ def test_add_conjugatefocksum_to_overlapping_conjugatefocksum():
     #     [0], [], []
     # ) + ConjugateFock([3], [2], [])
 
-    assert (fsum1 + fsum2).__str__() == "1.0 * ⟨1; 2; | + 2.0 * ⟨0; ; | + 1.0 * ⟨3; 2; |"
+    assert (
+        fsum1 + fsum2
+    ).__str__() == "1.0 * ⟨1; 2; | + 2.0 * ⟨0; ; | + 1.0 * ⟨3; 2; |"
 
 
 def test_conjugatefocksum_normlization():

--- a/tests/test_fockstate.py
+++ b/tests/test_fockstate.py
@@ -10,10 +10,9 @@ def test_fock_state_stores_correct_occupancies():
     coeff = 1.0
 
     fs = Fock(f_occ=f_occ, af_occ=af_occ, b_occ=b_occ)
-    assert fs.f_occ == f_occ
-    assert fs.af_occ == af_occ
-    assert fs.b_occ == b_occ
-    assert fs.coeff == coeff
+    assert list(next(iter(fs.state_dict)))[0] == tuple(f_occ)
+    assert list(next(iter(fs.state_dict)))[1] == tuple(af_occ)
+    assert list(next(iter(fs.state_dict)))[2] == tuple(b_occ)
 
 
 @pytest.mark.parametrize("coeff", np.random.uniform(-100, 100, size=10))
@@ -25,187 +24,98 @@ def test_fock_state_mul_by_constant(coeff):
     fs = Fock(f_occ=f_occ, af_occ=af_occ, b_occ=b_occ)
 
     fs_new = coeff * fs
-
-    assert fs_new.coeff == coeff * fs.coeff
+    assert list(fs_new.state_dict.values())[0] == coeff
 
 
 def test_fock_states_add_two_different_states():
     state_1 = Fock([1], [2], [(0, 4)])
     state_2 = Fock([0], [], [(1, 1)])
     state_sum = state_1 + state_2
-    # assert state_sum.__str__() == FockSum([state_1, state_2])
-    assert state_sum.__str__() == "1.0 * |1; 2; (0, 4)⟩ + 1.0 * |0; ; (1, 1)⟩"
+    assert (
+        state_sum.__str__()
+        == "1.0 * |((1,), (2,), ((0, 4),))⟩ +\n1.0 * |((0,), (), ((1, 1),))⟩"
+    )
 
 
 def test_fock_states_add_two_same_states():
     state = Fock([1], [2], [(0, 4)])
     # assert state + state == 2 * state
-    assert (state + state).__str__() == "2.0 * |1; 2; (0, 4)⟩"
+    assert (state + state).__str__() == "2.0 * |((1,), (2,), ((0, 4),))⟩"
 
 
 def test_add_fock_to_focksum():
     fsum = Fock([1], [2], []) + Fock([0], [], [])
     state = Fock([1], [], [])
 
-    # assert fsum + state == FockSum([fsum.states_list[0], fsum.states_list[1], state])
-    assert (fsum + state).__str__() == "1.0 * |1; 2; ⟩ + 1.0 * |0; ; ⟩ + 1.0 * |1; ; ⟩"
+    assert (
+        fsum + state
+    ).__str__() == "1.0 * |((1,), (2,), ())⟩ +\n1.0 * |((0,), (), ())⟩ +\n1.0 * |((1,), (), ())⟩"
 
 
 def test_add_focksum_to_fock_with_proper_ordering():
     fsum = Fock([1], [2], []) + Fock([0], [], [])
     state = Fock([1], [], [])
 
-    # assert state + fsum == FockSum([state, fsum.states_list[0], fsum.states_list[1]])
-    assert (state + fsum).__str__() == "1.0 * |1; ; ⟩ + 1.0 * |1; 2; ⟩ + 1.0 * |0; ; ⟩"
-
-
-# ?????????
-def test_add_focksum_to_fock_with_wrong_ordering():
-    fsum = Fock([1], [2], []) + Fock([0], [], [])
-    state = Fock([1], [], [])
-
-    assert state + fsum == FockSum([fsum.states_list[0], fsum.states_list[1], state])
-    assert (state + fsum).__str__() == "1.0 * |1; ; ⟩ + 1.0 * |1; 2; ⟩ + 1.0 * |0; ; ⟩"
-
-
-def test_add_focksum_to_different_focksum():
-    fsum1 = Fock([1], [2], []) + Fock([0], [], [])
-    fsum2 = Fock([3], [2], []) + Fock([1], [], [])
-
-    # assert fsum1 + fsum2 == FockSum(
-    #     [
-    #         fsum1.states_list[0],
-    #         fsum1.states_list[1],
-    #         fsum2.states_list[0],
-    #         fsum2.states_list[1],
-    #     ]
-    # )
-
     assert (
-        fsum1 + fsum2
-    ).__str__() == "1.0 * |1; 2; ⟩ + 1.0 * |0; ; ⟩ + 1.0 * |3; 2; ⟩ + 1.0 * |1; ; ⟩"
+        state + fsum
+    ).__str__() == "1.0 * |((1,), (2,), ())⟩ +\n1.0 * |((0,), (), ())⟩ +\n1.0 * |((1,), (), ())⟩"
 
 
-def test_add_focksum_to_overlapping_focksum():
-    fsum1 = Fock([1], [2], []) + Fock([0], [], [])
-    fsum2 = Fock([3], [2], []) + Fock([0], [], [])
-
-    # assert fsum1 + fsum2 == Fock([1], [2], []) + 2 * Fock([0], [], []) + Fock(
-    #     [3], [2], []
-    # )
-    assert (
-        fsum1 + fsum2
-    ).__str__() == "1.0 * |1; 2; ⟩ + 2.0 * |0; ; ⟩ + 1.0 * |3; 2; ⟩"
-
-
-def test_focksum_normlization():
-    fsum = Fock([1], [2], []) + Fock([0], [], [])
-    assert fsum.normalize() == 1 / np.sqrt(2) * fsum
+# def test_focksum_normlization():
+#     fsum = Fock([1], [2], []) + Fock([0], [], [])
+#     assert fsum.normalize() == 1 / np.sqrt(2) * fsum
 
 
 def test_conjugate_fock_state_stores_correct_occupancies():
     f_occ = [2]  # One fermion in mode 2
     af_occ = [1, 3]  # One antifermion in mode 1, one in mode 3
     b_occ = [(0, 3)]  # Three bosons in mode 0
-    coeff = 1.0
 
-    fs = ConjugateFock(f_occ=f_occ, af_occ=af_occ, b_occ=b_occ)
-    assert fs.f_occ == f_occ
-    assert fs.af_occ == af_occ
-    assert fs.b_occ == b_occ
-    assert fs.coeff == coeff
+    cfs = ConjugateFock(f_occ=f_occ, af_occ=af_occ, b_occ=b_occ)
+    assert list(next(iter(cfs.state_dict)))[0] == tuple(f_occ)
+    assert list(next(iter(cfs.state_dict)))[1] == tuple(af_occ)
+    assert list(next(iter(cfs.state_dict)))[2] == tuple(b_occ)
 
 
 @pytest.mark.parametrize("coeff", np.random.uniform(-100, 100, size=10))
-def test_conjugate_fock_state_mul_by_constant(coeff):
+def test_fock_state_mul_by_constant(coeff):
     f_occ = [2]  # One fermion in mode 2
     af_occ = [1, 3]  # One antifermion in mode 1, one in mode 3
     b_occ = [(0, 3)]  # Three bosons in mode 0
 
-    fs = ConjugateFock(f_occ=f_occ, af_occ=af_occ, b_occ=b_occ)
+    cfs = ConjugateFock(f_occ=f_occ, af_occ=af_occ, b_occ=b_occ)
 
-    fs_new = coeff * fs
-
-    assert fs_new.coeff == coeff * fs.coeff
+    cfs_new = coeff * cfs
+    assert list(cfs_new.state_dict.values())[0] == coeff
 
 
 def test_conjugate_fock_states_add_two_different_states():
     state_1 = ConjugateFock([1], [2], [(0, 4)])
     state_2 = ConjugateFock([0], [], [(1, 1)])
 
-    # assert state_1 + state_2 == ConjugateFockSum([state_1, state_2])
-    assert (state_1 + state_2).__str__() == "1.0 * ⟨1; 2; (0, 4)| + 1.0 * ⟨0; ; (1, 1)|"
+    assert (
+        state_1 + state_2
+    ).__str__() == "1.0 * ⟨((1,), (2,), ((0, 4),))| +\n1.0 * ⟨((0,), (), ((1, 1),))|"
 
 
 def test_conjugate_fock_states_add_two_same_states():
     state = ConjugateFock([1], [2], [(0, 4)])
     # assert state + state == 2 * state
-    assert (state + state).__str__() == "2.0 * ⟨1; 2; (0, 4)|"
+    assert (state + state).__str__() == "2.0 * ⟨((1,), (2,), ((0, 4),))|"
 
 
 def test_add_conjugatefock_to_conjugatefocksum():
     fsum = ConjugateFock([1], [2], []) + ConjugateFock([0], [], [])
     state = ConjugateFock([1], [], [])
 
-    # assert fsum + state == ConjugateFockSum(
-    #     [fsum.states_list[0], fsum.states_list[1], state]
-    # )
-    assert (fsum + state).__str__() == "1.0 * ⟨1; 2; | + 1.0 * ⟨0; ; | + 1.0 * ⟨1; ; |"
-
-
-def test_add_conjugatefocksum_to_conjugatefock_with_proper_ordering():
-    fsum = ConjugateFock([1], [2], []) + ConjugateFock([0], [], [])
-    state = ConjugateFock([1], [], [])
-
-    # assert state + fsum == ConjugateFockSum(
-    #     [state, fsum.states_list[0], fsum.states_list[1]]
-    # )
-    assert (fsum + state).__str__() == "1.0 * ⟨1; 2; | + 1.0 * ⟨0; ; | + 1.0 * ⟨1; ; |"
-
-
-def test_add_conjugatefocksum_to_conjugatefock_with_wrong_ordering():
-    fsum = ConjugateFock([1], [2], []) + ConjugateFock([0], [], [])
-    state = ConjugateFock([1], [], [])
-
-    assert state + fsum == ConjugateFockSum(
-        [fsum.states_list[0], fsum.states_list[1], state]
-    )
-
-
-def test_add_conjugatefocksum_to_different_conjugatefocksum():
-    fsum1 = ConjugateFock([1], [2], []) + ConjugateFock([0], [], [])
-    fsum2 = ConjugateFock([3], [2], []) + ConjugateFock([1], [], [])
-
-    # assert fsum1 + fsum2 == ConjugateFockSum(
-    #     [
-    #         fsum1.states_list[0],
-    #         fsum1.states_list[1],
-    #         fsum2.states_list[0],
-    #         fsum2.states_list[1],
-    #     ]
-    # )
-
     assert (
-        fsum1 + fsum2
-    ).__str__() == "1.0 * ⟨1; 2; | + 1.0 * ⟨0; ; | + 1.0 * ⟨3; 2; | + 1.0 * ⟨1; ; |"
+        fsum + state
+    ).__str__() == "1.0 * ⟨((1,), (2,), ())| +\n1.0 * ⟨((0,), (), ())| +\n1.0 * ⟨((1,), (), ())|"
 
 
-def test_add_conjugatefocksum_to_overlapping_conjugatefocksum():
-    fsum1 = ConjugateFock([1], [2], []) + ConjugateFock([0], [], [])
-    fsum2 = ConjugateFock([3], [2], []) + ConjugateFock([0], [], [])
-
-    # assert fsum1 + fsum2 == ConjugateFock([1], [2], []) + 2 * ConjugateFock(
-    #     [0], [], []
-    # ) + ConjugateFock([3], [2], [])
-
-    assert (
-        fsum1 + fsum2
-    ).__str__() == "1.0 * ⟨1; 2; | + 2.0 * ⟨0; ; | + 1.0 * ⟨3; 2; |"
-
-
-def test_conjugatefocksum_normlization():
-    fsum = ConjugateFock([1], [2], []) + ConjugateFock([0], [], [])
-    assert fsum.normalize() == 1 / np.sqrt(2) * fsum
+# def test_conjugatefocksum_normlization():
+#     fsum = ConjugateFock([1], [2], []) + ConjugateFock([0], [], [])
+#     assert fsum.normalize() == 1 / np.sqrt(2) * fsum
 
 
 @pytest.mark.parametrize("f_occ", np.random.uniform(0, 100, size=2))

--- a/tests/test_particleoperator.py
+++ b/tests/test_particleoperator.py
@@ -7,7 +7,7 @@ def test_particleoperator_generates_correctly():
     input_str = "b0^ b2 a3"
     particleop = ParticleOperator(input_str)
 
-    assert particleop.input_string == input_str
+    assert particleop.op_dict.popitem()[0] == input_str
 
 
 @pytest.mark.parametrize("coeff", np.random.uniform(-100, 100, size=10))
@@ -15,67 +15,43 @@ def test_coeoff_times_particleoperator(coeff):
     input_str = "b0^ b2 a3"
     particleop = coeff * ParticleOperator(input_str)
 
-    assert particleop.coeff == coeff
+    assert next(iter(particleop.op_dict.values())) == coeff
 
 
 def test_add_two_different_particleoperators():
     op1 = ParticleOperator("b0")
     op2 = ParticleOperator("b2")
 
-    opsum = op1 + op2
-
-    assert opsum == ParticleOperatorSum([op1, op2])
+    op = op1 + op2
+    opsum = ParticleOperator({"b0": 1, "b2": 1})
+    assert opsum.op_dict == op.op_dict
 
 
 def test_add_two_same_particleoperators():
     op1 = ParticleOperator("b0")
     op2 = ParticleOperator("b0")
 
-    assert op1 + op2 == 2 * ParticleOperator("b0")
+    assert (op1 + op2).op_dict == {"b0": 2}
 
 
 def test_add_particleoperatorsum_to_particleoperator():
     po = ParticleOperator("b0")
-    pos = ParticleOperatorSum([ParticleOperator("b1"), ParticleOperator("d1")])
+    pos = ParticleOperator({"b1": 1, "d1": 1})
+    out = ParticleOperator({"b1": 1, "d1": 1, "b0": 1})
 
-    assert po + pos == ParticleOperatorSum(
-        [po, pos.operator_list[0], pos.operator_list[1]]
-    )
-
-
-def test_add_particleoperator_to_particleoperatorsum():
-    po = ParticleOperator("b0")
-    pos = ParticleOperatorSum([ParticleOperator("b1"), ParticleOperator("d1")])
-
-    assert pos + po == ParticleOperatorSum(
-        [po, pos.operator_list[0], pos.operator_list[1]]
-    )
+    assert (po + pos).op_dict == out.op_dict
 
 
 def test_add_particleoperatorsums():
-    pos1 = ParticleOperatorSum([ParticleOperator("b1"), ParticleOperator("d1")])
-    pos2 = ParticleOperatorSum([ParticleOperator("a1"), ParticleOperator("a2")])
+    pos1 = ParticleOperator({"b1": 1, "d1": 1})
+    pos2 = ParticleOperator({"a1": 1, "a2": 1})
 
-    assert pos1 + pos2 == ParticleOperatorSum(
-        [
-            pos1.operator_list[0],
-            pos1.operator_list[1],
-            pos2.operator_list[0],
-            pos2.operator_list[1],
-        ]
-    )
-
-
-def test_add_overlapping_particleoperatorsums():
-    pos1 = ParticleOperatorSum([ParticleOperator("b1"), ParticleOperator("d1")])
-    pos2 = ParticleOperatorSum([ParticleOperator("b1"), ParticleOperator("a2")])
-
-    assert pos1 + pos2 == 2 * ParticleOperator("b1") + ParticleOperator(
-        "d1"
-    ) + ParticleOperator("a2")
+    assert (pos1 + pos2).op_dict == {"b1": 1, "d1": 1, "a1": 1, "a2": 1}
 
 
 @pytest.mark.parametrize("power", np.arange(1, 10, 1))
 def test_particle_operator_to_some_power(power):
     operator = ParticleOperator("a0")
-    assert operator**power == ParticleOperator((("a0" + " ") * power)[:-1])
+    assert (operator**power).op_dict == (
+        ParticleOperator((("a0" + " ") * power)[:-1])
+    ).op_dict

--- a/tests/test_particleoperator.py
+++ b/tests/test_particleoperator.py
@@ -1,4 +1,4 @@
-from openparticle import ParticleOperator, ParticleOperatorSum
+from openparticle import ParticleOperator
 import pytest
 import numpy as np
 


### PR DESCRIPTION
After this PR, OpenParticle will store `Fock` and `ParticleOperator` objects as hash tables rather than lists. 