### PR TITLE
Add .strip() such that I * op returns op and op * I returns op

### DIFF
--- a/openparticle/src.py
+++ b/openparticle/src.py
@@ -351,7 +351,8 @@ class ParticleOperator:
             product_dict = {}
             for op1, coeffs1 in list(self.op_dict.items()):
                 for op2, coeffs2 in list(other.op_dict.items()):
-                    product_dict[op1 + " " + op2] = coeffs1 * coeffs2
+                    # Add .strip() to remove trailing spaces when multipying with identity (treated as ' ')
+                    product_dict[(op1 + " " + op2).strip()] = coeffs1 * coeffs2
             return ParticleOperator(product_dict)
         return NotImplemented
 
@@ -378,8 +379,8 @@ class ParticleOperator:
         raise NotImplementedError()
 
     def max_mode(self):
-        all_ops_as_str = ' '.join(list(self.op_dict.keys()))
-        return max(list(map(lambda x: int(x), re.findall(r'\d+', all_ops_as_str))))
+        all_ops_as_str = " ".join(list(self.op_dict.keys()))
+        return max(list(map(lambda x: int(x), re.findall(r"\d+", all_ops_as_str))))
 
 
 class FermionOperator(ParticleOperator):


### PR DESCRIPTION
After this PR, identity operators will be implemented into the source code. This allows $A \times \mathbb{1} = \mathbb{1} \times A = A$.