### PR TITLE
Basis

### DIFF
--- a/openparticle/__init__.py
+++ b/openparticle/__init__.py
@@ -10,7 +10,7 @@ from .src import (
 )
 
 from .utils import (
-    generate_matrix_from_basis,
+    generate_matrix,
     get_fock_basis,
 )
 from .qubit_mappings import *

--- a/openparticle/__init__.py
+++ b/openparticle/__init__.py
@@ -9,5 +9,8 @@ from .src import (
     OccupationOperator,
 )
 
-from .utils import generate_matrix_from_basis, get_computational_states_fermionic
+from .utils import (
+    generate_matrix_from_basis,
+    get_fock_basis,
+)
 from .qubit_mappings import *

--- a/openparticle/utils.py
+++ b/openparticle/utils.py
@@ -83,7 +83,11 @@ def get_fock_basis(operator: ParticleOperator, max_bose_occ: int = 1):
     return basis
 
 
-def generate_matrix_from_basis(operator: ParticleOperator, basis: List[Fock]):
+def generate_matrix(
+    operator: ParticleOperator, basis: List[Fock] = None, max_bose_occ: int = 1
+):
+    if basis is None:
+        basis = get_fock_basis(operator=operator, max_bose_occ=max_bose_occ)
     size = (len(basis), len(basis))
     matrix = np.zeros(size)
 

--- a/openparticle/utils.py
+++ b/openparticle/utils.py
@@ -83,11 +83,7 @@ def get_fock_basis(operator: ParticleOperator, max_bose_occ: int = 1):
     return basis
 
 
-def generate_matrix(
-    operator: ParticleOperator, basis: List[Fock] = None, max_bose_occ: int = 1
-):
-    if basis is None:
-        basis = get_fock_basis(operator=operator, max_bose_occ=max_bose_occ)
+def generate_matrix(operator: ParticleOperator, basis: List[Fock]):
     size = (len(basis), len(basis))
     matrix = np.zeros(size)
 

--- a/openparticle/utils.py
+++ b/openparticle/utils.py
@@ -1,13 +1,86 @@
-from openparticle import Fock, ParticleOperator
+from openparticle import *
 import numpy as np
 from typing import List
+import itertools
 
 
-def get_computational_states_fermionic(n_modes):
-    return [
-        Fock([int(j) for j in format(i, "0" + str(n_modes) + "b")][::-1], [], [])
-        for i in range(2**n_modes)
-    ]
+def _fermion_combinations(n):
+    if n is None:
+        return []
+    else:
+        elements = list(range(n + 1))
+        result = []
+        for r in range(1, n + 2):  # Extend range to include the full list
+            result.extend(itertools.combinations(elements, r))
+        return [list(combo) for combo in result]
+
+
+def _give_me_state(nn, Lambda, Omega):
+    # Credit to Kamil Serafin
+    n = nn
+    result = list()
+    for i in range(Lambda):
+        r = n % (Omega + 1)
+        n = n // (Omega + 1)
+        result += [r]
+
+    return list(enumerate(result))
+
+
+def _boson_combinations(occupancy_cutoff, mode_cutoff):
+    if mode_cutoff is None:
+        return [[]]
+    else:
+        mode_cutoff += 1
+        boson_combos = []
+        for i in range((occupancy_cutoff + 1) ** mode_cutoff):
+            boson_combos.append(_give_me_state(i, mode_cutoff, occupancy_cutoff))
+
+        return boson_combos
+
+
+def _all_combinations_of_lists(*lists):
+    combinations = list(itertools.product(*lists))
+    return [list(combo) for combo in combinations]
+
+
+def _better_max(li):
+    return max(li) if li else None
+
+
+def get_fock_basis(operator: ParticleOperator, max_bose_occ: int = 1):
+    # Main function that obtains the basis for the corresponding operator
+
+    basis = []
+
+    fermion_ops = []
+    antifermion_ops = []
+    boson_ops = []
+
+    for op in operator.to_list():
+        for decomposed_op in op.split():
+            if isinstance(decomposed_op, FermionOperator):
+                fermion_ops.append(decomposed_op)
+            elif isinstance(decomposed_op, AntifermionOperator):
+                antifermion_ops.append(decomposed_op)
+            elif isinstance(decomposed_op, BosonOperator):
+                boson_ops.append(decomposed_op)
+
+    max_fermion_mode = _better_max([op.mode for op in fermion_ops])
+    max_antifermion_mode = _better_max([op.mode for op in antifermion_ops])
+    max_boson_mode = _better_max([op.mode for op in boson_ops])
+
+    f_combs = _fermion_combinations(max_fermion_mode)
+    af_combs = _fermion_combinations(max_antifermion_mode)
+    b_combs = _boson_combinations(max_bose_occ, max_boson_mode)
+
+    f_combs.insert(0, [])
+    af_combs.insert(0, [])
+
+    for i in _all_combinations_of_lists(f_combs, af_combs, b_combs):
+        basis.append(Fock(f_occ=i[0], af_occ=i[1], b_occ=i[2]))
+
+    return basis
 
 
 def generate_matrix_from_basis(operator: ParticleOperator, basis: List[Fock]):


### PR DESCRIPTION
After this PR, the functions `generate_matrix()` and `get_fock_basis()` will allow for the basis and the corresponding matrix for a general `ParticleOperator` to be generated.